### PR TITLE
Add Android SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - Cocoapods (`brew install cocoapods`)
 - jq (`brew install jq`) (optional)
 - Xcode (from the App Store)
+- Android Studio
 
 ```sh
 # clone the project
@@ -16,9 +17,10 @@ cd sdk-expo-example
 yarn install
 npx pod-install # (replaces `pod install` in React Native)
 
-# launch the iOS simulator
+# launch the Android/iOS apps
 # native code needs to be rebuilt after modifications, so you will need to re-run this on changes.
 yarn ios
+yarn android
 ```
 
 > **Troubleshooting tip:** if you encounter `SDK "iphoneos" cannot be located`, it might be a sign that your Xcode was installed from the command line. You can fix this by running: `sudo xcode-select --switch /Applications/Xcode.app`.
@@ -27,6 +29,7 @@ yarn ios
 
 Other than the basic React Native scaffolding and the SDK, this project uses two libraries:
 
+- [buffer](https://www.npmjs.com/package/buffer): to decode Base64 strings (31M+ weekly downloads)
 - [qrcode](https://www.npmjs.com/package/qrcode): to convert the byte array to an SVG (400k+ weekly downloads)
 - [react-native-svg](https://www.npmjs.com/package/react-native-svg): to display the SVG (300k+ weekly downloads)
 
@@ -65,7 +68,7 @@ EOF
 printf "User JWT:\n%s\n" $USER_JWT
 ```
 
-## Debugging
+## Debugging iOS
 
 Once your project is running, press `CMD` + `D` in the emulator, and enable "Debug mode".
 

--- a/SwiftCTRL.ts
+++ b/SwiftCTRL.ts
@@ -1,7 +1,8 @@
+import { Buffer } from 'buffer';
 import {
-  NativeModules,
-  NativeEventEmitter,
   EmitterSubscription,
+  NativeEventEmitter,
+  NativeModules,
 } from 'react-native';
 
 const { SwiftCTRLSDKModule } = NativeModules;
@@ -33,11 +34,16 @@ const initialize = (userToken: string, onInitialized: () => void) => {
 
 const registerForQRCode = (
   userToken: string,
-  onQRCodeReceived: (qrByteArray: Uint8Array) => void
+  onQRCodeReceived: (value: Uint8Array) => void
 ) => {
   qrCodeSubscription = eventEmitter.addListener(
     'didReceiveQRCode',
-    onQRCodeReceived
+    (value: string | Uint8Array) => {
+      // If the value is in base64, decode it first
+      const byteArray =
+        typeof value === 'string' ? Buffer.from(value, 'base64') : value;
+      onQRCodeReceived(byteArray);
+    }
   );
 
   SwiftCTRLSDKModule.registerForQRCode(userToken);

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -198,6 +198,12 @@ dependencies {
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // SwiftCTRL SDK
+    implementation ("com.swiftctrl:swiftctrl-sdk:1.0.0"){ changing = true }
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
     addUnimodulesDependencies()
 
     if (enableHermes) {

--- a/android/app/src/main/java/com/sdkexpoexample/MainApplication.java
+++ b/android/app/src/main/java/com/sdkexpoexample/MainApplication.java
@@ -43,6 +43,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       packages.add(new ModuleRegistryAdapter(mModuleRegistryProvider));
+      packages.add(new MyAppPackage());
       return packages;
     }
 

--- a/android/app/src/main/java/com/sdkexpoexample/MyAppPackage.java
+++ b/android/app/src/main/java/com/sdkexpoexample/MyAppPackage.java
@@ -1,0 +1,27 @@
+package com.sdkexpoexample;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MyAppPackage implements ReactPackage {
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+
+        modules.add(new SwiftCTRLModule(reactContext));
+
+        return modules;
+    }
+}

--- a/android/app/src/main/java/com/sdkexpoexample/SwiftCTRLModule.java
+++ b/android/app/src/main/java/com/sdkexpoexample/SwiftCTRLModule.java
@@ -1,0 +1,79 @@
+package com.sdkexpoexample;
+
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.swiftctrl.sdk.SwiftCtrlCallback;
+import com.swiftctrl.sdk.connector.SwiftCtrlManualClient;
+
+import org.jetbrains.annotations.NotNull;
+
+public class SwiftCTRLModule extends ReactContextBaseJavaModule implements @NotNull SwiftCtrlCallback {
+    private SwiftCtrlManualClient client;
+
+    SwiftCTRLModule(ReactApplicationContext context) {
+        super(context);
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "SwiftCTRLSDKModule";
+    }
+
+    @ReactMethod
+    public void initialize(String userToken) {
+        Log.d("Android Bridge", "initialize: " + userToken);
+
+        ReactContext context = getReactApplicationContext();
+
+        client = new SwiftCtrlManualClient(context, userToken, this);
+        client.connect();
+    }
+
+    @ReactMethod
+    public void registerForQRCode(String userToken) {
+        Log.d("Android Bridge", "registerForQRCode: " + userToken);
+        client.registerCryptoFeed();
+    }
+
+    @ReactMethod
+    public void unregisterForQRCode(String userToken) {
+        Log.d("Android Bridge", "unregisterForQRCode: " + userToken);
+        client.unregisterCryptoFeed();
+    }
+
+    @ReactMethod
+    public void disconnect() {
+        Log.d("Android Bridge", "disconnect");
+        client.disconnect();
+    }
+
+    @Override
+    public void onSwiftCtrlReady() {
+        Log.d("Android Bridge", "onSwiftCtrlReady");
+        sendEvent("didFinishInitialization", null);
+    }
+
+    @Override
+    public void onSwiftCtrlCrypto(@NotNull String base64, @NotNull byte[] bytes) {
+        Log.d("Android Bridge", "onSwiftCtrlCrypto");
+        sendEvent("didReceiveQRCode", base64);
+    }
+
+    @Override
+    public void onSwiftCtrlError(@NotNull String s, @org.jetbrains.annotations.Nullable Exception e) {
+        Log.e("Android Bridge", "onSwiftCtrlError", e);
+    }
+
+    private void sendEvent(String eventName, @Nullable Object param) {
+        getReactApplicationContext()
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(eventName, param);
+    }
+}

--- a/android/app/src/main/java/com/sdkexpoexample/generated/BasePackageList.java
+++ b/android/app/src/main/java/com/sdkexpoexample/generated/BasePackageList.java
@@ -1,0 +1,26 @@
+package com.sdkexpoexample.generated;
+
+import java.util.Arrays;
+import java.util.List;
+import org.unimodules.core.interfaces.Package;
+
+public class BasePackageList {
+  public List<Package> getPackageList() {
+    return Arrays.<Package>asList(
+        new expo.modules.application.ApplicationPackage(),
+        new expo.modules.constants.ConstantsPackage(),
+        new expo.modules.errorrecovery.ErrorRecoveryPackage(),
+        new expo.modules.filesystem.FileSystemPackage(),
+        new expo.modules.font.FontLoaderPackage(),
+        new expo.modules.imageloader.ImageLoaderPackage(),
+        new expo.modules.keepawake.KeepAwakePackage(),
+        new expo.modules.lineargradient.LinearGradientPackage(),
+        new expo.modules.location.LocationPackage(),
+        new expo.modules.permissions.PermissionsPackage(),
+        new expo.modules.securestore.SecureStorePackage(),
+        new expo.modules.splashscreen.SplashScreenPackage(),
+        new expo.modules.sqlite.SQLitePackage(),
+        new expo.modules.updates.UpdatesPackage()
+    );
+  }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,13 +3,15 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 29
         targetSdkVersion = 29
     }
     repositories {
         google()
         jcenter()
+
+        maven { url "https://swiftctrl.jfrog.io/artifactory/libs-release-local/" }
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
@@ -34,5 +36,7 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://www.jitpack.io' }
+
+        maven { url "https://swiftctrl.jfrog.io/artifactory/libs-release-local/" }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -27,3 +27,5 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.54.0
+
+org.gradle.jvmargs=-Xmx4096m

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "expo": "~40.0.0",
     "expo-splash-screen": "~0.8.0",
     "expo-updates": "~0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,6 +2692,14 @@ buffer@^5.2.0, buffer@^5.4.3:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -4322,7 +4330,7 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
**Changes**

- Adds the Swift Android SDK
- Updates the app code to accept a Base64 string (see [this change](https://github.com/SwiftCTRL/sdk-expo-example/compare/android-sdk?expand=1#diff-4d1bc6ef7139bae96913f01df94a35b6d82d126749a010339335a9a6717c327e))

Adds one new library to the project:

- [buffer](https://www.npmjs.com/package/buffer): to decode Base64 strings (31M+ weekly downloads)